### PR TITLE
fix: leak on runtime errors, explanation on the github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ test-results/
 # Ignorer les fichiers de sauvegarde
 *~
 *.bak
+ft_irc-tester

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,12 +1,12 @@
-/* Copyright 2024 <faboussa>************************************************* */
+/* Copyright 2024 <mbernard>************************************************* */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
 /*   Server.cpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: faboussa <faboussa@student.42.fr>          +#+  +:+       +#+        */
+/*   By: mbernard <mbernard@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/17 11:50:56 by faboussa          #+#    #+#             */
-/*   Updated: 2024/11/06 19:41:59 by faboussa         ###   ########.fr       */
+/*   Updated: 2024/11/12 12:09:58 by mbernard         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -164,6 +164,7 @@ void Server::closeServer(void) {
   _pollFds.clear();
   shrink_to_fit(&_pollFds);
   _channels.clear();
+  delete gConfig;
 }
 
 /*============================================================================*/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: mbernard <mbernard@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/17 11:50:56 by mbernard          #+#    #+#             */
-/*   Updated: 2024/11/12 11:42:55 by mbernard         ###   ########.fr       */
+/*   Updated: 2024/11/12 12:03:19 by mbernard         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,11 +47,11 @@ int main(int ac, char** argv) {
     signal(SIGQUIT, Server::signalHandler);
     initServerConfig();
     ser.runServer();
-    ser.closeServer();
   } catch (const std::runtime_error& e) {
     std::cerr << RED << e.what() << RESET << '\n';
     exitCode = EXIT_FAILURE;
   }
+  ser.closeServer();
   if (exitCode == EXIT_SUCCESS)
     std::cout << "The Server is closed" << std::endl;
   delete gConfig;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: mbernard <mbernard@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/17 11:50:56 by mbernard          #+#    #+#             */
-/*   Updated: 2024/11/12 12:03:19 by mbernard         ###   ########.fr       */
+/*   Updated: 2024/11/12 12:10:43 by mbernard         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,6 @@ int main(int ac, char** argv) {
   int port = std::atoi(argv[1]);
   std::string password = argv[2];
   checkArgs(port, password);
-  int exitCode = EXIT_SUCCESS;
   Server ser(port, password);
 
   try {
@@ -49,11 +48,10 @@ int main(int ac, char** argv) {
     ser.runServer();
   } catch (const std::runtime_error& e) {
     std::cerr << RED << e.what() << RESET << '\n';
-    exitCode = EXIT_FAILURE;
+    ser.closeServer();
+    return (EXIT_FAILURE);
   }
   ser.closeServer();
-  if (exitCode == EXIT_SUCCESS)
-    std::cout << "The Server is closed" << std::endl;
-  delete gConfig;
-  exit(exitCode);
+  std::cout << "The Server is closed" << std::endl;
+  return (EXIT_SUCCESS);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,12 @@
-/* Copyright 2024 <faboussa>************************************************* */
+/* Copyright 2024 <mbernard>************************************************* */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
 /*   main.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: faboussa <faboussa@student.42.fr>          +#+  +:+       +#+        */
+/*   By: mbernard <mbernard@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/17 11:50:56 by mbernard          #+#    #+#             */
-/*   Updated: 2024/11/06 19:44:16 by faboussa         ###   ########.fr       */
+/*   Updated: 2024/11/12 11:42:55 by mbernard         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,6 +39,7 @@ int main(int ac, char** argv) {
   int port = std::atoi(argv[1]);
   std::string password = argv[2];
   checkArgs(port, password);
+  int exitCode = EXIT_SUCCESS;
   Server ser(port, password);
 
   try {
@@ -46,13 +47,13 @@ int main(int ac, char** argv) {
     signal(SIGQUIT, Server::signalHandler);
     initServerConfig();
     ser.runServer();
-  } catch (const std::exception& e) {
-    std::cerr << RED << e.what() << RESET << '\n';
     ser.closeServer();
-    exit(EXIT_FAILURE);
+  } catch (const std::runtime_error& e) {
+    std::cerr << RED << e.what() << RESET << '\n';
+    exitCode = EXIT_FAILURE;
   }
-  ser.closeServer();
-  std::cout << "The Server is closed" << std::endl;
+  if (exitCode == EXIT_SUCCESS)
+    std::cout << "The Server is closed" << std::endl;
   delete gConfig;
-  exit(EXIT_SUCCESS);
+  exit(exitCode);
 }


### PR DESCRIPTION
Fix the leak when either of the runtime errors occurs from `Server::createSocket`. Issue : #33 

## Explanation
### Original problem
:one: : The main didn't catch the **std::runtime_error** but searched for **std::exception**, and they're not the same thing :warning:
:two: : Exiting before the main was ended leaded to the server not to be free because **his scope (the main scoped) would never end properly with the `exit(EXIT_FAILURE)`**.
:three: : The gconfig would be deleted only if the server didn't catch any error.

### Fix
:one: : Changing  **std::exception** for **std::runtime_error**.
Since std::exception is used nowhere (there are std::runtime_error everywhere when you search `throw` ), no need to keep std::exception. If we were to use it again, we would just add another catch to the main.
:two: : Erased the `exit(EXIT_FAILURE)` from the catch block. Replaced by a `return(EXIT_FAILURE)`.
:three: : Placed `delete gconfig` at the end of **closeServer()**.