### PR TITLE
fix: stop multiple messages

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -121,12 +121,6 @@ void Channel::checkAndremoveClientFromTheChannel(int fd) {
   if (_channelClients.find(fd) != _channelClients.end()) {
     {
       std::ostringstream oss;
-      _channelClients[fd]->receiveMessage(
-          FROM_SERVER + "NOTICE" + " " +
-          "You have been removed from the channel\r\n");
-    }
-    {
-      std::ostringstream oss;
       oss << "Client " << fd << " removed from channel " << _name;
       Server::printLog(INFO_LOG, CHANNEL, oss.str());
     }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -216,7 +216,9 @@ void Server::closeClient(int fd) {
 
 void Server::clearClient(int fd) {
   channelsMap::iterator itEnd = _channels.end();
+  bool wasInaChannel = false;
   for (channelsMap::iterator it = _channels.begin(); it != itEnd; ++it) {
+    wasInaChannel = true;
     if (it->second.getInvitedClients().find(fd) !=
         it->second.getInvitedClients().end())
       it->second.removeClientFromInvitedMap(&_clients.at(fd));
@@ -225,6 +227,10 @@ void Server::clearClient(int fd) {
       it->second.removeOperator(&_clients.at(fd));
     it->second.checkAndremoveClientFromTheChannel(fd);
   }
+  if (wasInaChannel)
+    _clients[fd].receiveMessage(
+      FROM_SERVER + "NOTICE" + " " +
+        "You have been removed from the channel\r\n");
   closeClient(fd);
   for (size_t i = 0; i < _pollFds.size(); i++) {
     if (_pollFds[i].fd == fd) {

--- a/src/commands/quit.cpp
+++ b/src/commands/quit.cpp
@@ -39,6 +39,7 @@ void Server::quit(const std::string &argument, Client *client,
   }
   message += " ; User " + client->getRealName() + " has quit IRC.";
   message += "\r\n";
+  
   clearClient(client->getFd());
   clientsMap::iterator itEnd = cltMap->end();
   for (clientsMap::iterator it = cltMap->begin(); it != itEnd; ++it) {


### PR DESCRIPTION
Problems was in Channels.cpp, not in QUIT.

Fix : sends only one message about being removed when the client is cleared